### PR TITLE
Add unique AppID method

### DIFF
--- a/src/main/java/com/bakdata/common_kafka_streams/KafkaStreamsApplication.java
+++ b/src/main/java/com/bakdata/common_kafka_streams/KafkaStreamsApplication.java
@@ -104,7 +104,7 @@ public abstract class KafkaStreamsApplication implements Runnable {
     public abstract void buildTopology(StreamsBuilder builder);
 
     /**
-     * This must be set to a unique value within the entire Kafka cluster.
+     * This must be set to a unique value for every application interacting with your kafka cluster to ensure internal state encapsulation. 
      * Could be set to: className-inputTopic-outputTopic
      */
     public abstract String getUniqueAppId();

--- a/src/main/java/com/bakdata/common_kafka_streams/KafkaStreamsApplication.java
+++ b/src/main/java/com/bakdata/common_kafka_streams/KafkaStreamsApplication.java
@@ -103,6 +103,12 @@ public abstract class KafkaStreamsApplication implements Runnable {
 
     public abstract void buildTopology(StreamsBuilder builder);
 
+    /**
+     * This must be set to an unique value within the entire Kafka cluster.
+     * Could be set to: className-inputTopic-outputTopic
+     */
+    public abstract String getUniqueAppId();
+
     public Topology createTopology() {
         final StreamsBuilder builder = new StreamsBuilder();
         this.buildTopology(builder);
@@ -141,7 +147,7 @@ public abstract class KafkaStreamsApplication implements Runnable {
         kafkaConfig.setProperty(StreamsConfig.producerPrefix(ProducerConfig.COMPRESSION_TYPE_CONFIG), "gzip");
 
         // topology
-        kafkaConfig.setProperty(StreamsConfig.APPLICATION_ID_CONFIG, this.getClass().getSimpleName());
+        kafkaConfig.put(StreamsConfig.APPLICATION_ID_CONFIG, this.getUniqueAppId());
         kafkaConfig.put(StreamsConfig.DEFAULT_KEY_SERDE_CLASS_CONFIG, SpecificAvroSerde.class);
         kafkaConfig.put(StreamsConfig.DEFAULT_VALUE_SERDE_CLASS_CONFIG, SpecificAvroSerde.class);
         kafkaConfig.setProperty(AbstractKafkaAvroSerDeConfig.SCHEMA_REGISTRY_URL_CONFIG, this.getSchemaRegistryUrl());

--- a/src/main/java/com/bakdata/common_kafka_streams/KafkaStreamsApplication.java
+++ b/src/main/java/com/bakdata/common_kafka_streams/KafkaStreamsApplication.java
@@ -104,7 +104,7 @@ public abstract class KafkaStreamsApplication implements Runnable {
     public abstract void buildTopology(StreamsBuilder builder);
 
     /**
-     * This must be set to an unique value within the entire Kafka cluster.
+     * This must be set to a unique value within the entire Kafka cluster.
      * Could be set to: className-inputTopic-outputTopic
      */
     public abstract String getUniqueAppId();

--- a/src/test/java/com/bakdata/common_kafka_streams/test_applications/WordCount.java
+++ b/src/test/java/com/bakdata/common_kafka_streams/test_applications/WordCount.java
@@ -69,6 +69,11 @@ public class WordCount extends KafkaStreamsApplication {
         wordCounts.toStream().to(this.outputTopic, Produced.with(stringSerde, longSerde));
     }
 
+    @Override
+    public String getUniqueAppId() {
+        return this.getClass().getSimpleName() + "-" + this.getInputTopic() + "-" + this.getOutputTopic();
+    }
+
     public Properties getKafkaProperties() {
         final Properties kafkaConfig = super.getKafkaProperties();
         kafkaConfig.setProperty(StreamsConfig.DEFAULT_KEY_SERDE_CLASS_CONFIG, Serdes.String().getClass().getName());


### PR DESCRIPTION
Each stream application needs a unique value within the entire Kafka cluster. Usually, this could be set to: className-inputTopic-outputTopic.