### PR TITLE
Add CLI parameter to allow reprocessing of data

### DIFF
--- a/src/main/java/com/bakdata/common_kafka_streams/KafkaStreamsApplication.java
+++ b/src/main/java/com/bakdata/common_kafka_streams/KafkaStreamsApplication.java
@@ -40,6 +40,7 @@ import org.apache.kafka.streams.StreamsConfig;
 import org.apache.kafka.streams.Topology;
 import org.apache.log4j.Level;
 import picocli.CommandLine;
+import picocli.CommandLine.Option;
 
 
 /**
@@ -66,6 +67,9 @@ public abstract class KafkaStreamsApplication implements Runnable {
     private boolean debug = false;
     @CommandLine.Option(names = {"-h", "--help"}, usageHelp = true, description = "print this help and exit")
     private boolean helpRequested = false;
+    @CommandLine.Option(names = "--reprocess", arity = "1", description = "Reprocess all data by clearing the state store beforehand")
+    private boolean forceReprocessing = false;
+
     private KafkaStreams streams;
 
     private static String[] addEnvironmentVariablesArguments(final String[] args) {
@@ -105,6 +109,11 @@ public abstract class KafkaStreamsApplication implements Runnable {
         log.debug(this.toString());
         final var kafkaProperties = this.getKafkaProperties();
         this.streams = new KafkaStreams(this.createTopology(), kafkaProperties);
+
+        if (this.forceReprocessing) {
+            this.streams.cleanUp();
+        }
+
         this.streams.start();
 
         Runtime.getRuntime().addShutdownHook(new Thread(() -> this.streams.close()));

--- a/src/main/java/com/bakdata/common_kafka_streams/KafkaStreamsApplication.java
+++ b/src/main/java/com/bakdata/common_kafka_streams/KafkaStreamsApplication.java
@@ -40,7 +40,6 @@ import org.apache.kafka.streams.StreamsConfig;
 import org.apache.kafka.streams.Topology;
 import org.apache.log4j.Level;
 import picocli.CommandLine;
-import picocli.CommandLine.Option;
 
 
 /**


### PR DESCRIPTION
This PR adds a parameter to allow and force reprocessing of data in a Kafka Streams Applications. This is especially useful for test scenarios, in which we would otherwise continue working on the same, old state.