### PR TITLE
Change reprocessing to clean up

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -48,7 +48,7 @@ allprojects {
         "testImplementation"("org.junit.jupiter:junit-jupiter-api:5.4.0")
         "testRuntimeOnly"("org.junit.jupiter:junit-jupiter-engine:5.4.0")
         "testImplementation"(group = "org.assertj", name = "assertj-core", version = "3.11.1")
-        "testImplementation"(group = "com.bakdata.fluent-kafka-streams-tests", name = "fluent-kafka-streams-tests-junit5", version = "2.0.1")
+        "testImplementation"(group = "com.bakdata.fluent-kafka-streams-tests", name = "fluent-kafka-streams-tests-junit5", version = "2.0.2-SNAPSHOT")
         "testImplementation"(group = "org.apache.kafka", name = "kafka-streams-test-utils", version = "2.2.0")
         "testImplementation"(group = "com.bakdata.fluent-kafka-streams-tests", name = "schema-registry-mock-junit5", version = "2.0.0") {
             exclude(group = "junit")

--- a/src/main/java/com/bakdata/common_kafka_streams/KafkaStreamsApplication.java
+++ b/src/main/java/com/bakdata/common_kafka_streams/KafkaStreamsApplication.java
@@ -241,8 +241,5 @@ public abstract class KafkaStreamsApplication implements Runnable, AutoCloseable
             Thread.currentThread().interrupt();
             throw new RuntimeException(e);
         }
-        this.close();
     }
-
-
 }

--- a/src/main/java/com/bakdata/common_kafka_streams/KafkaStreamsApplication.java
+++ b/src/main/java/com/bakdata/common_kafka_streams/KafkaStreamsApplication.java
@@ -85,7 +85,7 @@ public abstract class KafkaStreamsApplication implements Runnable, AutoCloseable
     private boolean cleanUp = false;
 
     @CommandLine.Option(names = "--delete-output", arity = "1",
-            description = "Delete the output topic during the clean up. ")
+            description = "Delete the output topic during the clean up.")
     private boolean deleteOutputTopic = false;
 
     @CommandLine.Option(names = "--streams-config", split = ",", description = "Additional Kafka Streams properties")

--- a/src/test/java/com/bakdata/common_kafka_streams/WordCountTest.java
+++ b/src/test/java/com/bakdata/common_kafka_streams/WordCountTest.java
@@ -45,11 +45,11 @@ class WordCountTest {
 
     @Test
     void shouldAggregateSameWordStream() {
-        this.testTopology.input().add("bla")
+        this.testTopology.input("Input").add("bla")
                 .add("blub")
                 .add("bla");
 
-        this.testTopology.streamOutput().withSerde(Serdes.String(), Serdes.Long())
+        this.testTopology.streamOutput("Output").withSerde(Serdes.String(), Serdes.Long())
                 .expectNextRecord().hasKey("bla").hasValue(1L)
                 .expectNextRecord().hasKey("blub").hasValue(1L)
                 .expectNextRecord().hasKey("bla").hasValue(2L)

--- a/src/test/java/com/bakdata/common_kafka_streams/WordCountTest.java
+++ b/src/test/java/com/bakdata/common_kafka_streams/WordCountTest.java
@@ -45,11 +45,11 @@ class WordCountTest {
 
     @Test
     void shouldAggregateSameWordStream() {
-        this.testTopology.input("Input").add("bla")
+        this.testTopology.input().add("bla")
                 .add("blub")
                 .add("bla");
 
-        this.testTopology.streamOutput("Output").withSerde(Serdes.String(), Serdes.Long())
+        this.testTopology.streamOutput().withSerde(Serdes.String(), Serdes.Long())
                 .expectNextRecord().hasKey("bla").hasValue(1L)
                 .expectNextRecord().hasKey("blub").hasValue(1L)
                 .expectNextRecord().hasKey("bla").hasValue(2L)

--- a/src/test/java/com/bakdata/common_kafka_streams/integration/CleanUpTest.java
+++ b/src/test/java/com/bakdata/common_kafka_streams/integration/CleanUpTest.java
@@ -38,7 +38,6 @@ import net.mguenther.kafka.junit.KeyValue;
 import net.mguenther.kafka.junit.ReadKeyValues;
 import net.mguenther.kafka.junit.SendValuesTransactional;
 import net.mguenther.kafka.junit.TopicConfig;
-import org.apache.kafka.streams.StreamsConfig;
 import org.assertj.core.api.JUnitJupiterSoftAssertions;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;

--- a/src/test/java/com/bakdata/common_kafka_streams/test_applications/Mirror.java
+++ b/src/test/java/com/bakdata/common_kafka_streams/test_applications/Mirror.java
@@ -39,7 +39,6 @@ public class Mirror extends KafkaStreamsApplication {
 
     @Override
     public String getUniqueAppId() {
-        return this.getClass().getSimpleName() + "-" + String.join("-", this.getInputTopics()) +
-                "-" + this.getOutputTopic();
+        return this.getClass().getSimpleName() + "-" + this.getInputTopic() + "-" + this.getOutputTopic();
     }
 }

--- a/src/test/java/com/bakdata/common_kafka_streams/test_applications/WordCount.java
+++ b/src/test/java/com/bakdata/common_kafka_streams/test_applications/WordCount.java
@@ -62,8 +62,7 @@ public class WordCount extends KafkaStreamsApplication {
 
     @Override
     public String getUniqueAppId() {
-        return this.getClass().getSimpleName() + "-" + String.join("-", this.getInputTopics()) +
-                "-" + this.getOutputTopic();
+        return this.getClass().getSimpleName() + "-" + this.getInputTopic() + "-" + this.getOutputTopic();
     }
 
     public Properties getKafkaProperties() {

--- a/src/test/java/com/bakdata/common_kafka_streams/test_applications/WordCount.java
+++ b/src/test/java/com/bakdata/common_kafka_streams/test_applications/WordCount.java
@@ -35,6 +35,7 @@ import org.apache.kafka.streams.StreamsBuilder;
 import org.apache.kafka.streams.StreamsConfig;
 import org.apache.kafka.streams.kstream.KStream;
 import org.apache.kafka.streams.kstream.KTable;
+import org.apache.kafka.streams.kstream.Materialized;
 import org.apache.kafka.streams.kstream.Produced;
 
 @NoArgsConstructor
@@ -54,7 +55,7 @@ public class WordCount extends KafkaStreamsApplication {
         final KTable<String, Long> wordCounts = textLines
                 .flatMapValues(value -> Arrays.asList(pattern.split(value.toLowerCase())))
                 .groupBy((key, word) -> word)
-                .count();
+                .count(Materialized.as("counts"));
 
         wordCounts.toStream().to(this.outputTopic, Produced.with(stringSerde, longSerde));
     }


### PR DESCRIPTION
Starting the application with the cleanUp flag, all corresponding state dirs, offsets und internal topics are deleted. However, it does not reprocess the data and exists when it is done.