### PR TITLE
Fix schema registry clean up

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -50,9 +50,9 @@ allprojects {
         "testImplementation"("org.junit.jupiter:junit-jupiter-params:5.4.0")
         "testRuntimeOnly"("org.junit.jupiter:junit-jupiter-engine:5.4.0")
         "testImplementation"(group = "org.assertj", name = "assertj-core", version = "3.13.2")
-        "testImplementation"(group = "com.bakdata.fluent-kafka-streams-tests", name = "fluent-kafka-streams-tests-junit5", version = "2.0.3")
+        "testImplementation"(group = "com.bakdata.fluent-kafka-streams-tests", name = "fluent-kafka-streams-tests-junit5", version = "2.0.4")
         "testImplementation"(group = "org.apache.kafka", name = "kafka-streams-test-utils", version = "2.2.0")
-        "testImplementation"(group = "com.bakdata.fluent-kafka-streams-tests", name = "schema-registry-mock-junit5", version = "2.0.3") {
+        "testImplementation"(group = "com.bakdata.fluent-kafka-streams-tests", name = "schema-registry-mock-junit5", version = "2.0.4") {
             exclude(group = "junit")
         }
         "testImplementation"(group = "net.mguenther.kafka", name = "kafka-junit", version = "2.1.0") {

--- a/src/main/java/com/bakdata/common_kafka_streams/KafkaStreamsApplication.java
+++ b/src/main/java/com/bakdata/common_kafka_streams/KafkaStreamsApplication.java
@@ -285,10 +285,16 @@ public abstract class KafkaStreamsApplication implements Runnable, AutoCloseable
             final String keySubject = topic + "-key";
             if (allSubjects.contains(keySubject)) {
                 client.deleteSubject(keySubject);
+                log.info("Cleaned key schema of topic {}", topic);
+            } else {
+                log.info("No key schema for topic {} available", topic);
             }
             final String valueSubject = topic + "-value";
             if (allSubjects.contains(valueSubject)) {
                 client.deleteSubject(valueSubject);
+                log.info("Cleaned value schema of topic {}", topic);
+            } else {
+                log.info("No value schema for topic {} available", topic);
             }
         } catch (final IOException | RestClientException e) {
             log.error("Could not reset schema registry", e);

--- a/src/main/java/com/bakdata/common_kafka_streams/KafkaStreamsApplication.java
+++ b/src/main/java/com/bakdata/common_kafka_streams/KafkaStreamsApplication.java
@@ -33,6 +33,7 @@ import java.io.IOException;
 import java.lang.Thread.UncaughtExceptionHandler;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -277,13 +278,20 @@ public abstract class KafkaStreamsApplication implements Runnable, AutoCloseable
         }
     }
 
-    private void resetSchemaRegistry(final String topic) {
+    protected void resetSchemaRegistry(final String topic) {
         final SchemaRegistryClient client = new CachedSchemaRegistryClient(this.schemaRegistryUrl, 100);
         try {
-            client.deleteSubject(topic + "-key");
-            client.deleteSubject(topic + "-value");
+            final Collection<String> allSubjects = client.getAllSubjects();
+            final String keySubject = topic + "-key";
+            if (allSubjects.contains(keySubject)) {
+                client.deleteSubject(keySubject);
+            }
+            final String valueSubject = topic + "-value";
+            if (allSubjects.contains(valueSubject)) {
+                client.deleteSubject(valueSubject);
+            }
         } catch (final IOException | RestClientException e) {
-            log.error("Could not rest schema registry", e);
+            log.error("Could not reset schema registry", e);
         }
     }
 


### PR DESCRIPTION
Prior to this PR, key and value schemas of topic where deleted from schema registry regardless whether they existed or not. This was not covered by the tests because the SchemaRegistryMock did not appropriately behave in this scenario. However, a real schema registry would throw an exception in such a case. This PR fixes the schema registry clean up and uses an updated version of the mock.