### PR TITLE
Configure StreamsResetter with application properties

### DIFF
--- a/src/main/java/com/bakdata/common_kafka_streams/CleanUpRunner.java
+++ b/src/main/java/com/bakdata/common_kafka_streams/CleanUpRunner.java
@@ -30,9 +30,12 @@ import com.bakdata.common_kafka_streams.util.TopologyInformation;
 import io.confluent.kafka.schemaregistry.client.CachedSchemaRegistryClient;
 import io.confluent.kafka.schemaregistry.client.SchemaRegistryClient;
 import io.confluent.kafka.schemaregistry.client.rest.exceptions.RestClientException;
+import java.io.File;
+import java.io.FileOutputStream;
 import java.io.IOException;
 import java.util.Collection;
 import java.util.List;
+import java.util.Map;
 import java.util.Properties;
 import kafka.tools.StreamsResetter;
 import lombok.Builder;
@@ -75,7 +78,7 @@ public class CleanUpRunner {
     }
 
     public void run(final boolean deleteOutputTopic) {
-        runResetter(String.join(",", this.inputTopics), this.brokers, this.appId);
+        runResetter(String.join(",", this.inputTopics), this.brokers, this.appId, this.kafkaProperties);
         if (deleteOutputTopic) {
             this.deleteTopics();
         }
@@ -88,14 +91,31 @@ public class CleanUpRunner {
         }
     }
 
-    public static void runResetter(final String inputTopics, final String brokers, final String appId) {
+    public static void runResetter(final String inputTopics, final String brokers, final String appId,
+            final Properties config) {
+        // StreamsResetter's internal AdminClient can only be configured with a properties file
+        final File tempFile = createTemporaryPropertiesFile(appId, config);
         final String[] args = {
                 "--application-id", appId,
                 "--bootstrap-servers", brokers,
-                "--input-topics", inputTopics
+                "--input-topics", inputTopics,
+                "--config-file", tempFile.toString()
         };
         final StreamsResetter resetter = new StreamsResetter();
         resetter.run(args);
+    }
+
+    private static File createTemporaryPropertiesFile(final String appId, final Properties config) {
+        try {
+            final File tempFile = File.createTempFile(appId + "-reset", "temp");
+            tempFile.deleteOnExit();
+            try (final FileOutputStream out = new FileOutputStream(tempFile)) {
+                config.store(out, "");
+            }
+            return tempFile;
+        } catch (final IOException e) {
+            throw new RuntimeException("Could not run StreamsResetter", e);
+        }
     }
 
     public void deleteTopics() {

--- a/src/main/java/com/bakdata/common_kafka_streams/CleanUpRunner.java
+++ b/src/main/java/com/bakdata/common_kafka_streams/CleanUpRunner.java
@@ -105,19 +105,6 @@ public class CleanUpRunner {
         resetter.run(args);
     }
 
-    private static File createTemporaryPropertiesFile(final String appId, final Properties config) {
-        try {
-            final File tempFile = File.createTempFile(appId + "-reset", "temp");
-            tempFile.deleteOnExit();
-            try (final FileOutputStream out = new FileOutputStream(tempFile)) {
-                config.store(out, "");
-            }
-            return tempFile;
-        } catch (final IOException e) {
-            throw new RuntimeException("Could not run StreamsResetter", e);
-        }
-    }
-
     public void deleteTopics() {
         // the StreamsResetter is responsible for deleting internal topics
         this.topologyInformation.getInternalTopics().forEach(this::resetSchemaRegistry);
@@ -160,5 +147,25 @@ public class CleanUpRunner {
         }
     }
 
+    protected static File createTemporaryPropertiesFile(final String appId, final Properties config) {
+        // Writing properties requires Map<String, String>
+        final Properties parsedProperties = toStringBasedProperties(config);
+        try {
+            final File tempFile = File.createTempFile(appId + "-reset", "temp");
+            tempFile.deleteOnExit();
+            try (final FileOutputStream out = new FileOutputStream(tempFile)) {
+                parsedProperties.store(out, "");
+            }
+            return tempFile;
+        } catch (final IOException e) {
+            throw new RuntimeException("Could not run StreamsResetter", e);
+        }
+    }
+
+    protected static Properties toStringBasedProperties(final Properties config) {
+        final Properties parsedProperties = new Properties();
+        config.forEach((key, value) -> parsedProperties.setProperty(key.toString(), value.toString()));
+        return parsedProperties;
+    }
 
 }

--- a/src/test/java/com/bakdata/common_kafka_streams/CleanUpRunnerTest.java
+++ b/src/test/java/com/bakdata/common_kafka_streams/CleanUpRunnerTest.java
@@ -1,0 +1,34 @@
+package com.bakdata.common_kafka_streams;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.bakdata.common_kafka_streams.test_applications.WordCount;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.util.List;
+import java.util.Properties;
+import org.apache.kafka.streams.StreamsConfig;
+import org.junit.jupiter.api.Test;
+
+class CleanUpRunnerTest {
+
+    @Test
+    void createTemporaryPropertiesFile() throws IOException {
+        final WordCount wordCount = new WordCount();
+        wordCount.setInputTopics(List.of("input"));
+        final File file = CleanUpRunner.createTemporaryPropertiesFile(wordCount.getUniqueAppId(),
+                wordCount.getKafkaProperties());
+
+        assertThat(file.exists());
+
+        final Properties properties = new Properties();
+        try (final FileInputStream inStream = new FileInputStream(file)) {
+            properties.load(inStream);
+        }
+
+        final Properties expected = CleanUpRunner.toStringBasedProperties(wordCount.getKafkaProperties());
+        assertThat(properties).containsAllEntriesOf(expected);
+    }
+}


### PR DESCRIPTION
This PR adds propagating of the application's properties to the internal `StreamsResetter`. Among others, it allows interacting with a secured cluster.