### PR TITLE
Add hook for Streams state transitions

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -61,7 +61,7 @@ allprojects {
         }
         "implementation"(group = "org.apache.kafka", name = "kafka_2.11", version = kafkaVersion)
 
-        "api"(group = "info.picocli", name = "picocli", version = "2.3.0")
+        "api"(group = "info.picocli", name = "picocli", version = "4.0.4")
         "api"(group = "org.apache.kafka", name = "kafka-streams", version = kafkaVersion)
         val confluentVersion: String by project
         "implementation"(group = "io.confluent", name = "kafka-streams-avro-serde", version = confluentVersion)

--- a/src/main/java/com/bakdata/common_kafka_streams/KafkaStreamsApplication.java
+++ b/src/main/java/com/bakdata/common_kafka_streams/KafkaStreamsApplication.java
@@ -38,6 +38,8 @@ import lombok.Data;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.kafka.clients.producer.ProducerConfig;
 import org.apache.kafka.streams.KafkaStreams;
+import org.apache.kafka.streams.KafkaStreams.State;
+import org.apache.kafka.streams.KafkaStreams.StateListener;
 import org.apache.kafka.streams.StreamsBuilder;
 import org.apache.kafka.streams.StreamsConfig;
 import org.apache.kafka.streams.Topology;
@@ -56,47 +58,41 @@ import picocli.CommandLine;
 @Data
 @Slf4j
 public abstract class KafkaStreamsApplication implements Runnable, AutoCloseable {
+    public static final int RESET_SLEEP_MS = 5000;
     private static final String ENV_PREFIX = Optional.ofNullable(
             System.getenv("ENV_PREFIX")).orElse("APP_");
-    public static final int RESET_SLEEP_MS = 5000;
-
+    /**
+     * This variable is usually set on application start. When the application is running in debug mode it is used to
+     * reconfigure the child app package logger. On default it points to the package of this class allowing to execute
+     * the run method independently.
+     */
+    private static String appPackageName = KafkaStreamsApplication.class.getPackageName();
+    @CommandLine.Option(names = "--input-topics", description = "Input topics", split = ",")
+    protected List<String> inputTopics = new ArrayList<>();
+    @CommandLine.Option(names = "--output-topic", description = "Output topic")
+    protected String outputTopic = "";
+    @CommandLine.Option(names = "--error-topic", description = "Error topic (default: ${DEFAULT-VALUE}")
+    protected String errorTopic = "error_topic";
     @CommandLine.Option(names = "--brokers", required = true)
     private String brokers = "";
-
     @CommandLine.Option(names = "--schema-registry-url", required = true)
     private String schemaRegistryUrl = "";
-
     @CommandLine.Option(names = "--productive", arity = "1")
     private boolean productive = true;
-
     @CommandLine.Option(names = "--debug", arity = "1")
     private boolean debug = false;
-
     @CommandLine.Option(names = {"-h", "--help"}, usageHelp = true, description = "print this help and exit")
     private boolean helpRequested = false;
-
     @CommandLine.Option(names = "--clean-up", arity = "1",
             description = "Clear the state store and the global Kafka offsets for the "
                     + "consumer group. Be careful with running in production and with enabling this flag - it "
                     + "might cause inconsistent processing with multiple replicas.")
     private boolean cleanUp = false;
-
     @CommandLine.Option(names = "--delete-output", arity = "1",
             description = "Delete the output topic during the clean up.")
     private boolean deleteOutputTopic = false;
-
     @CommandLine.Option(names = "--streams-config", split = ",", description = "Additional Kafka Streams properties")
     private Map<String, String> streamsConfig = new HashMap<>();
-
-    @CommandLine.Option(names = "--input-topics", description = "Input topics", split = ",")
-    protected List<String> inputTopics = new ArrayList<>();
-
-    @CommandLine.Option(names = "--output-topic", description = "Output topic")
-    protected String outputTopic = "";
-
-    @CommandLine.Option(names = "--error-topic", description = "Error topic (default: ${DEFAULT-VALUE}")
-    protected String errorTopic = "error_topic";
-
     private KafkaStreams streams;
 
     private static String[] addEnvironmentVariablesArguments(final String[] args) {
@@ -106,13 +102,6 @@ public abstract class KafkaStreamsApplication implements Runnable, AutoCloseable
         allArgs.addAll(Arrays.asList(args));
         return allArgs.toArray(String[]::new);
     }
-
-    /**
-     * This variable is usually set on application start. When the application is running in debug mode it is used to
-     * reconfigure the child app package logger. On default it points to the package of this class allowing to execute
-     * the run method independently.
-     */
-    private static String appPackageName = KafkaStreamsApplication.class.getPackageName();
 
     /**
      * <p>This methods needs to be called in the executable custom application class inheriting from
@@ -140,6 +129,8 @@ public abstract class KafkaStreamsApplication implements Runnable, AutoCloseable
         this.streams = new KafkaStreams(this.createTopology(), kafkaProperties);
         Optional.ofNullable(this.getUncaughtExceptionHandler())
                 .ifPresent(this.streams::setUncaughtExceptionHandler);
+        Optional.ofNullable(this.getStateListener())
+                .ifPresent(this.streams::setStateListener);
 
         if (this.cleanUp) {
             this.runCleanUp();
@@ -148,14 +139,10 @@ public abstract class KafkaStreamsApplication implements Runnable, AutoCloseable
         }
     }
 
-    protected UncaughtExceptionHandler getUncaughtExceptionHandler() {
-        return null;
-    }
-
-
     @Override
     public void close() {
         log.info("Stopping application");
+        this.closeResources();
         if (this.streams == null) {
             return;
         }
@@ -189,6 +176,24 @@ public abstract class KafkaStreamsApplication implements Runnable, AutoCloseable
         this.streamsConfig.forEach(kafkaConfig::setProperty);
 
         return kafkaConfig;
+    }
+
+    public String getInputTopic() {
+        if (this.getInputTopics().isEmpty() || this.getInputTopics().get(0).isBlank()) {
+            throw new IllegalArgumentException("One input topic required");
+        }
+        return this.getInputTopics().get(0);
+    }
+
+    /**
+     * Create an {@link UncaughtExceptionHandler} to use for Kafka Streams. Will not be configured if {@code null} is
+     * returned.
+     *
+     * @return {@code null} by default.
+     * @see KafkaStreams#setUncaughtExceptionHandler(UncaughtExceptionHandler)
+     */
+    protected UncaughtExceptionHandler getUncaughtExceptionHandler() {
+        return null;
     }
 
     /**
@@ -238,6 +243,29 @@ public abstract class KafkaStreamsApplication implements Runnable, AutoCloseable
     }
 
     /**
+     * Method to close resources outside of {@link KafkaStreams}. Will be called by default on {@link #close()} and on
+     * transitioning to {@link State#ERROR}.
+     */
+    protected void closeResources() {
+        //do nothing by default
+    }
+
+    /**
+     * Create a {@link StateListener} to use for Kafka Streams. Will not be configured if {@code null} is returned.
+     *
+     * @return {@link StateListener} that calls {@link #closeResources()} on transition to {@link State#ERROR}.
+     * @see KafkaStreams#setStateListener(StateListener)
+     */
+    protected StateListener getStateListener() {
+        return (newState, oldState) -> {
+            if (newState == State.ERROR) {
+                log.info("Kafka Streams transitioned from {} to {}", oldState, State.ERROR);
+                KafkaStreamsApplication.this.closeResources();
+            }
+        };
+    }
+
+    /**
      * This methods resets the offset for all input topics and deletes internal topics, application state, and
      * optionally the output and error topic.
      */
@@ -258,12 +286,5 @@ public abstract class KafkaStreamsApplication implements Runnable, AutoCloseable
 
     protected void cleanUpRun(final CleanUpRunner cleanUpRunner) {
         cleanUpRunner.run(this.deleteOutputTopic);
-    }
-
-    public String getInputTopic() {
-        if (this.getInputTopics().isEmpty() || this.getInputTopics().get(0).isBlank()) {
-            throw new IllegalArgumentException("One input topic required");
-        }
-        return this.getInputTopics().get(0);
     }
 }

--- a/src/test/java/com/bakdata/common_kafka_streams/integration/RunAppTest.java
+++ b/src/test/java/com/bakdata/common_kafka_streams/integration/RunAppTest.java
@@ -1,0 +1,173 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2020 bakdata
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package com.bakdata.common_kafka_streams.integration;
+
+import static net.mguenther.kafka.junit.EmbeddedKafkaCluster.provisionWith;
+import static net.mguenther.kafka.junit.EmbeddedKafkaClusterConfig.useDefaults;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.bakdata.common_kafka_streams.KafkaStreamsApplication;
+import com.bakdata.common_kafka_streams.test_applications.Mirror;
+import com.bakdata.schemaregistrymock.junit5.SchemaRegistryMockExtension;
+import java.util.List;
+import java.util.Properties;
+import java.util.concurrent.TimeUnit;
+import lombok.Getter;
+import net.mguenther.kafka.junit.EmbeddedKafkaCluster;
+import net.mguenther.kafka.junit.KeyValue;
+import net.mguenther.kafka.junit.ReadKeyValues;
+import net.mguenther.kafka.junit.SendKeyValuesTransactional;
+import net.mguenther.kafka.junit.TopicConfig;
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.clients.producer.ProducerConfig;
+import org.apache.kafka.common.serialization.Serdes;
+import org.apache.kafka.common.serialization.StringDeserializer;
+import org.apache.kafka.common.serialization.StringSerializer;
+import org.apache.kafka.streams.StreamsBuilder;
+import org.apache.kafka.streams.StreamsConfig;
+import org.apache.kafka.streams.kstream.KStream;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+class RunAppTest {
+    private static final int TIMEOUT_SECONDS = 10;
+    @RegisterExtension
+    final SchemaRegistryMockExtension schemaRegistryMockExtension = new SchemaRegistryMockExtension();
+    private EmbeddedKafkaCluster kafkaCluster;
+    private KafkaStreamsApplication app = null;
+
+    @BeforeEach
+    void setup() {
+        this.kafkaCluster = provisionWith(useDefaults());
+        this.kafkaCluster.start();
+    }
+
+    @AfterEach
+    void teardown() throws InterruptedException {
+        if (this.app != null) {
+            this.app.close();
+            this.app = null;
+        }
+
+        Thread.sleep(TimeUnit.SECONDS.toMillis(TIMEOUT_SECONDS));
+        this.kafkaCluster.stop();
+    }
+
+    @Test
+    void shouldRunApp() throws InterruptedException {
+        final String input = "input";
+        final String output = "output";
+        this.kafkaCluster.createTopic(TopicConfig.forTopic(input).useDefaults());
+        this.kafkaCluster.createTopic(TopicConfig.forTopic(output).useDefaults());
+        this.app = new Mirror();
+        this.app.setBrokers(this.kafkaCluster.getBrokerList());
+        this.app.setSchemaRegistryUrl(this.schemaRegistryMockExtension.getUrl());
+        this.app.setInputTopics(List.of(input));
+        this.app.setOutputTopic(output);
+        this.app.run();
+        final SendKeyValuesTransactional<String, String> kvSendKeyValuesTransactionalBuilder =
+                SendKeyValuesTransactional.inTransaction(input, List.of(new KeyValue<>("foo", "bar")))
+                        .with(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class)
+                        .with(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, StringSerializer.class)
+                        .build();
+        this.kafkaCluster.send(kvSendKeyValuesTransactionalBuilder);
+        Thread.sleep(TimeUnit.SECONDS.toMillis(TIMEOUT_SECONDS));
+        assertThat(this.kafkaCluster.read(ReadKeyValues.from(output, String.class, String.class)
+                .with(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class)
+                .with(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class)
+                .build()))
+                .hasSize(1);
+    }
+
+    @Test
+    void shouldCallCloseResourcesOnMissingInputTopic() throws InterruptedException {
+        final String input = "input";
+        final String output = "output";
+        this.kafkaCluster.createTopic(TopicConfig.forTopic(output).useDefaults());
+        final CloseResourcesApplication closeResourcesApplication = new CloseResourcesApplication();
+        this.app = closeResourcesApplication;
+        this.app.setBrokers(this.kafkaCluster.getBrokerList());
+        this.app.setSchemaRegistryUrl(this.schemaRegistryMockExtension.getUrl());
+        this.app.setInputTopics(List.of(input));
+        this.app.setOutputTopic(output);
+        this.app.run();
+        Thread.sleep(TimeUnit.SECONDS.toMillis(TIMEOUT_SECONDS));
+        assertThat(closeResourcesApplication.getCalled()).isEqualTo(1);
+    }
+
+    @Test
+    void shouldCallCloseResourcesOnMapError() throws InterruptedException {
+        final String input = "input";
+        final String output = "output";
+        this.kafkaCluster.createTopic(TopicConfig.forTopic(input).useDefaults());
+        this.kafkaCluster.createTopic(TopicConfig.forTopic(output).useDefaults());
+        final CloseResourcesApplication closeResourcesApplication = new CloseResourcesApplication();
+        this.app = closeResourcesApplication;
+        this.app.setBrokers(this.kafkaCluster.getBrokerList());
+        this.app.setSchemaRegistryUrl(this.schemaRegistryMockExtension.getUrl());
+        this.app.setInputTopics(List.of(input));
+        this.app.setOutputTopic(output);
+        this.app.run();
+        final SendKeyValuesTransactional<String, String> kvSendKeyValuesTransactionalBuilder =
+                SendKeyValuesTransactional.inTransaction(input, List.of(new KeyValue<>("foo", "bar")))
+                        .with(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class)
+                        .with(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, StringSerializer.class)
+                        .build();
+        this.kafkaCluster.send(kvSendKeyValuesTransactionalBuilder);
+        Thread.sleep(TimeUnit.SECONDS.toMillis(TIMEOUT_SECONDS));
+        assertThat(closeResourcesApplication.getCalled()).isEqualTo(1);
+    }
+
+    private static class CloseResourcesApplication extends KafkaStreamsApplication {
+        @Getter
+        private int called = 0;
+
+        @Override
+        public void buildTopology(final StreamsBuilder builder) {
+            final KStream<String, String> input = builder.stream(this.getInputTopic());
+            input.map((k, v) -> {throw new RuntimeException();}).to(this.getOutputTopic());
+        }
+
+        @Override
+        public String getUniqueAppId() {
+            return this.getClass().getSimpleName() + "-" + this.getInputTopic() + "-" + this.getOutputTopic();
+        }
+
+        @Override
+        protected void closeResources() {
+            this.called++;
+        }
+
+        @Override
+        protected Properties createKafkaProperties() {
+            final Properties kafkaProperties = super.createKafkaProperties();
+            kafkaProperties.put(StreamsConfig.DEFAULT_VALUE_SERDE_CLASS_CONFIG, Serdes.StringSerde.class);
+            kafkaProperties.put(StreamsConfig.DEFAULT_KEY_SERDE_CLASS_CONFIG, Serdes.StringSerde.class);
+            return kafkaProperties;
+        }
+    }
+}

--- a/src/test/java/com/bakdata/common_kafka_streams/test_applications/Mirror.java
+++ b/src/test/java/com/bakdata/common_kafka_streams/test_applications/Mirror.java
@@ -25,8 +25,11 @@
 package com.bakdata.common_kafka_streams.test_applications;
 
 import com.bakdata.common_kafka_streams.KafkaStreamsApplication;
+import java.util.Properties;
 import lombok.NoArgsConstructor;
+import org.apache.kafka.common.serialization.Serdes;
 import org.apache.kafka.streams.StreamsBuilder;
+import org.apache.kafka.streams.StreamsConfig;
 import org.apache.kafka.streams.kstream.KStream;
 
 @NoArgsConstructor
@@ -40,5 +43,13 @@ public class Mirror extends KafkaStreamsApplication {
     @Override
     public String getUniqueAppId() {
         return this.getClass().getSimpleName() + "-" + this.getInputTopic() + "-" + this.getOutputTopic();
+    }
+
+    @Override
+    protected Properties createKafkaProperties() {
+        final Properties kafkaProperties = super.createKafkaProperties();
+        kafkaProperties.put(StreamsConfig.DEFAULT_VALUE_SERDE_CLASS_CONFIG, Serdes.StringSerde.class);
+        kafkaProperties.put(StreamsConfig.DEFAULT_KEY_SERDE_CLASS_CONFIG, Serdes.StringSerde.class);
+        return kafkaProperties;
     }
 }


### PR DESCRIPTION
This PR adds a hook for registering a `StateListener`. By default, `closeResources()` is called if the state transitions to ERROR.