### PR TITLE
Fix KEDA HPA names

### DIFF
--- a/charts/kafka-app/templates/_helpers.tpl
+++ b/charts/kafka-app/templates/_helpers.tpl
@@ -426,14 +426,3 @@ metadata:
     {{ $key | quote }}: {{ $value | quote }}
     {{- end }}
 {{- end }}
-
-{{- define "kafka-app.scaled-object-name" -}}
-{{/*
-KEDA adds prefix keda-hpa- to HPA and name of HPA must not exceed 63 characters
-*/}}
-{{- if ge (len (include "kafka-app.fullname" .)) 54 }}
-{{- printf "%s-%s" (include "kafka-app.fullname" . | trunc 48 | trimSuffix "-") (include "kafka-app.fullname" . | sha1sum | trunc 5) }}
-{{- else}}
-{{- include "kafka-app.fullname" . }}
-{{- end }}
-{{- end }}

--- a/charts/kafka-app/templates/_helpers.tpl
+++ b/charts/kafka-app/templates/_helpers.tpl
@@ -426,3 +426,14 @@ metadata:
     {{ $key | quote }}: {{ $value | quote }}
     {{- end }}
 {{- end }}
+
+{{- define "kafka-app.scaled-object-name" -}}
+{{/*
+KEDA adds prefix keda-hpa- to HPA and name of HPA must not exceed 63 characters
+*/}}
+{{- if ge (len (include "kafka-app.fullname" .)) 54 }}
+{{- printf "%s-%s" (include "kafka-app.fullname" . | trunc 48 | trimSuffix "-") (include "kafka-app.fullname" . | sha1sum | trunc 5) }}
+{{- else}}
+{{- include "kafka-app.fullname" . }}
+{{- end }}
+{{- end }}

--- a/charts/kafka-app/templates/_scaled-object.yaml
+++ b/charts/kafka-app/templates/_scaled-object.yaml
@@ -8,8 +8,7 @@
 apiVersion: keda.sh/v1alpha1
 kind: ScaledObject
 metadata:
-  # KEDA adds prefix keda-hpa- to HPA and name of HPA must not exceed 63 characters
-  name: {{ include "kafka-app.fullname" . | trunc 54 | trimSuffix "-" }}
+  name: {{ include "kafka-app.scaled-object-name" . }}
   {{- include "kafka-app.annotations" . }}
   labels:
     {{- include "kafka-app.labels" . | nindent 4 }}

--- a/charts/kafka-app/templates/_scaled-object.yaml
+++ b/charts/kafka-app/templates/_scaled-object.yaml
@@ -8,7 +8,8 @@
 apiVersion: keda.sh/v1alpha1
 kind: ScaledObject
 metadata:
-  name: {{ include "kafka-app.fullname" . }}-so
+  # KEDA adds prefix keda-hpa- to HPA and name of HPA must not exceed 63 characters
+  name: {{ include "kafka-app.fullname" . | trunc 54 | trimSuffix "-" }}
   {{- include "kafka-app.annotations" . }}
   labels:
     {{- include "kafka-app.labels" . | nindent 4 }}

--- a/charts/kafka-app/templates/_scaled-object.yaml
+++ b/charts/kafka-app/templates/_scaled-object.yaml
@@ -8,7 +8,7 @@
 apiVersion: keda.sh/v1alpha1
 kind: ScaledObject
 metadata:
-  name: {{ include "kafka-app.scaled-object-name" . }}
+  name: {{ include "kafka-app.fullname" . }}
   {{- include "kafka-app.annotations" . }}
   labels:
     {{- include "kafka-app.labels" . | nindent 4 }}
@@ -83,5 +83,8 @@ spec:
   {{- if .Values.autoscaling.additionalTriggers }}
   {{- .Values.autoscaling.additionalTriggers | toYaml | nindent 4 }}
   {{- end }}
+  advanced:
+    horizontalPodAutoscalerConfig:
+      name: {{ include "kafka-app.fullname" . }}
 {{ end }}
 {{- end -}}


### PR DESCRIPTION
KEDA HPAs are prefixed with `keda-hpa-` by default. Additionally, the HPA name lenght limit is 63 characters. Therefore, we should set the HPA name manually and remove the scaledobject suffix