### PR TITLE
Add explicit KEDA triggers and scaling modifiers

### DIFF
--- a/charts/consumer-app/README.md
+++ b/charts/consumer-app/README.md
@@ -121,6 +121,8 @@ podAnnotations:
 | `autoscaling.idleReplicas`       | https://keda.sh/docs/2.10/concepts/scaling-deployments/#idlereplicacount                                           |            |
 | `autoscaling.topics`             | List of topics used by the consumer app.                                                                           | `[]`       |
 | `autoscaling.additionalTriggers` | List of additional KEDA triggers, see https://keda.sh/docs/latest/scalers/                                         | `[]`       |
+| `autoscaling.triggers`           | Complete KEDA trigger list. A non-empty list replaces all generated Kafka lag triggers.                            | `[]`       |
+| `autoscaling.scalingModifiers`   | KEDA composite scaling configuration. Requires explicit triggers and KEDA 2.12 or newer.                           |            |
 
 ### JVM
 

--- a/charts/consumer-app/README.md
+++ b/charts/consumer-app/README.md
@@ -122,7 +122,7 @@ podAnnotations:
 | `autoscaling.topics`             | List of topics used by the consumer app.                                                                           | `[]`       |
 | `autoscaling.additionalTriggers` | List of additional KEDA triggers, see https://keda.sh/docs/latest/scalers/                                         | `[]`       |
 | `autoscaling.triggers`           | Complete KEDA trigger list. A non-empty list replaces all generated Kafka lag triggers.                            | `[]`       |
-| `autoscaling.scalingModifiers`   | KEDA composite scaling configuration. Requires explicit triggers and KEDA 2.12 or newer.                           |            |
+| `autoscaling.scalingModifiers`   | KEDA composite scaling configuration. Requires explicit triggers.                                                  |            |
 
 ### JVM
 

--- a/charts/consumer-app/values.yaml
+++ b/charts/consumer-app/values.yaml
@@ -115,8 +115,7 @@ autoscaling:
   ## fully replaces automatically generated Kafka lag triggers when non-empty;
   ## mutually exclusive with additionalTriggers
   triggers: []
-  ## appended to automatically generated Kafka lag triggers in managed Kafka mode;
-  ## cannot be used without a Kafka topic source
+  ## appended to automatically generated Kafka lag triggers, or used as the sole trigger source
   additionalTriggers: []
 #    - type: metrics-api
 #      metadata:

--- a/charts/consumer-app/values.yaml
+++ b/charts/consumer-app/values.yaml
@@ -112,12 +112,23 @@ autoscaling:
   topics: []
   #   - bar
   #   - baz
+  ## fully replaces automatically generated Kafka lag triggers when non-empty;
+  ## mutually exclusive with additionalTriggers
+  triggers: []
+  ## appended to automatically generated Kafka lag triggers in managed Kafka mode;
+  ## cannot be used without a Kafka topic source
   additionalTriggers: []
 #    - type: metrics-api
 #      metadata:
 #        targetValue: "2"
 #        url: "http://custom-metrics-api"
 #        valueLocation: "some.json.path"
+  ## requires KEDA 2.12+ and explicit triggers
+  # scalingModifiers:
+  #   formula: "trigger_a + trigger_b"
+  #   target: "2"
+  #   activationTarget: "0"
+  #   metricType: AverageValue
 
 # serviceAccountName: foo
 

--- a/charts/consumer-app/values.yaml
+++ b/charts/consumer-app/values.yaml
@@ -123,7 +123,7 @@ autoscaling:
 #        targetValue: "2"
 #        url: "http://custom-metrics-api"
 #        valueLocation: "some.json.path"
-  ## requires KEDA 2.12+ and explicit triggers
+  ## requires explicit triggers
   # scalingModifiers:
   #   formula: "trigger_a + trigger_b"
   #   target: "2"

--- a/charts/consumerproducer-app/README.md
+++ b/charts/consumerproducer-app/README.md
@@ -125,7 +125,7 @@ podAnnotations:
 | `autoscaling.topics`             | List of topics used by the consumerproducer app.                                                         | `[]`       |
 | `autoscaling.additionalTriggers` | List of additional KEDA triggers, see https://keda.sh/docs/latest/scalers/                               | `[]`       |
 | `autoscaling.triggers`           | Complete KEDA trigger list. A non-empty list replaces all generated Kafka lag triggers.                  | `[]`       |
-| `autoscaling.scalingModifiers`   | KEDA composite scaling configuration. Requires explicit triggers and KEDA 2.12 or newer.                 |            |
+| `autoscaling.scalingModifiers`   | KEDA composite scaling configuration. Requires explicit triggers.                                        |            |
 
 ### JVM
 

--- a/charts/consumerproducer-app/README.md
+++ b/charts/consumerproducer-app/README.md
@@ -124,6 +124,8 @@ podAnnotations:
 | `autoscaling.idleReplicas`       | https://keda.sh/docs/2.10/concepts/scaling-deployments/#idlereplicacount                                 |            |
 | `autoscaling.topics`             | List of topics used by the consumerproducer app.                                                         | `[]`       |
 | `autoscaling.additionalTriggers` | List of additional KEDA triggers, see https://keda.sh/docs/latest/scalers/                               | `[]`       |
+| `autoscaling.triggers`           | Complete KEDA trigger list. A non-empty list replaces all generated Kafka lag triggers.                  | `[]`       |
+| `autoscaling.scalingModifiers`   | KEDA composite scaling configuration. Requires explicit triggers and KEDA 2.12 or newer.                 |            |
 
 ### JVM
 

--- a/charts/consumerproducer-app/values.yaml
+++ b/charts/consumerproducer-app/values.yaml
@@ -127,7 +127,7 @@ autoscaling:
 #        targetValue: "2"
 #        url: "http://custom-metrics-api"
 #        valueLocation: "some.json.path"
-  ## requires KEDA 2.12+ and explicit triggers
+  ## requires explicit triggers
   # scalingModifiers:
   #   formula: "trigger_a + trigger_b"
   #   target: "2"

--- a/charts/consumerproducer-app/values.yaml
+++ b/charts/consumerproducer-app/values.yaml
@@ -116,12 +116,23 @@ autoscaling:
   topics: []
   #   - bar
   #   - baz
+  ## fully replaces automatically generated Kafka lag triggers when non-empty;
+  ## mutually exclusive with additionalTriggers
+  triggers: []
+  ## appended to automatically generated Kafka lag triggers in managed Kafka mode;
+  ## cannot be used without a Kafka topic source
   additionalTriggers: []
 #    - type: metrics-api
 #      metadata:
 #        targetValue: "2"
 #        url: "http://custom-metrics-api"
 #        valueLocation: "some.json.path"
+  ## requires KEDA 2.12+ and explicit triggers
+  # scalingModifiers:
+  #   formula: "trigger_a + trigger_b"
+  #   target: "2"
+  #   activationTarget: "0"
+  #   metricType: AverageValue
 
 # serviceAccountName: foo
 

--- a/charts/consumerproducer-app/values.yaml
+++ b/charts/consumerproducer-app/values.yaml
@@ -119,8 +119,7 @@ autoscaling:
   ## fully replaces automatically generated Kafka lag triggers when non-empty;
   ## mutually exclusive with additionalTriggers
   triggers: []
-  ## appended to automatically generated Kafka lag triggers in managed Kafka mode;
-  ## cannot be used without a Kafka topic source
+  ## appended to automatically generated Kafka lag triggers, or used as the sole trigger source
   additionalTriggers: []
 #    - type: metrics-api
 #      metadata:

--- a/charts/kafka-app/README.md
+++ b/charts/kafka-app/README.md
@@ -176,7 +176,7 @@ podAnnotations:
 ### Auto-Scaling
 
 | Parameter                        | Description                                                                                                        | Default    |
-| -------------------------------- | ------------------------------------------------------------------------------------------------------------------ | ---------- |
+| -------------------------------- |--------------------------------------------------------------------------------------------------------------------| ---------- |
 | `autoscaling.enabled`            | Whether to enable auto-scaling using [KEDA](https://keda.sh/docs/latest/scalers/apache-kafka/).                    | `false`    |
 | `autoscaling.lagThreshold`       | Average target value to trigger scaling actions.                                                                   |            |
 | `autoscaling.pollingInterval`    | https://keda.sh/docs/2.10/concepts/scaling-deployments/#pollinginterval                                            | `30`       |
@@ -189,7 +189,7 @@ podAnnotations:
 | `autoscaling.topics`             | List of topics used by the streams app.                                                                            | `[]`       |
 | `autoscaling.additionalTriggers` | List of additional KEDA triggers, see https://keda.sh/docs/latest/scalers/                                         | `[]`       |
 | `autoscaling.triggers`           | Complete KEDA trigger list. A non-empty list replaces all generated Kafka lag triggers.                            | `[]`       |
-| `autoscaling.scalingModifiers`   | KEDA composite scaling configuration. Requires explicit triggers and KEDA 2.12 or newer.                           |            |
+| `autoscaling.scalingModifiers`   | KEDA composite scaling configuration. Requires explicit triggers.                                                  |            |
 
 ### JVM
 

--- a/charts/kafka-app/README.md
+++ b/charts/kafka-app/README.md
@@ -188,6 +188,8 @@ podAnnotations:
 | `autoscaling.internalTopics`     | List of auto-generated Kafka Streams topics used by the streams app. Consumer group prefix is added automatically. | `[]`       |
 | `autoscaling.topics`             | List of topics used by the streams app.                                                                            | `[]`       |
 | `autoscaling.additionalTriggers` | List of additional KEDA triggers, see https://keda.sh/docs/latest/scalers/                                         | `[]`       |
+| `autoscaling.triggers`           | Complete KEDA trigger list. A non-empty list replaces all generated Kafka lag triggers.                            | `[]`       |
+| `autoscaling.scalingModifiers`   | KEDA composite scaling configuration. Requires explicit triggers and KEDA 2.12 or newer.                           |            |
 
 ### JVM
 

--- a/charts/kafka-app/templates/_scaled-object.yaml
+++ b/charts/kafka-app/templates/_scaled-object.yaml
@@ -1,8 +1,20 @@
 {{- define "kafka-app.scaled-object" -}}
 {{ if .Values.autoscaling.enabled }}
   {{- $uniqueId := coalesce .Values.kafka.applicationId .Values.kafka.groupId -}}
-  {{- if not (and $uniqueId .Values.autoscaling.lagThreshold) }}
-  {{- fail "When autoscaling is enabled, you must set both .Values.kafka.applicationId (or .Values.kafka.groupId) and .Values.autoscaling.lagThreshold" }}
+  {{- $explicitTriggers := .Values.autoscaling.triggers | default list -}}
+  {{- $additionalTriggers := .Values.autoscaling.additionalTriggers | default list -}}
+  {{- $scalingModifiers := .Values.autoscaling.scalingModifiers | default dict -}}
+  {{- $hasTopicSources := or .Values.kafka.inputTopics .Values.autoscaling.internalTopics .Values.autoscaling.topics .Values.kafka.labeledInputTopics -}}
+  {{- if and $explicitTriggers $additionalTriggers }}
+  {{- fail "autoscaling.triggers and autoscaling.additionalTriggers cannot be used together" }}
+  {{- end }}
+  {{- if not $explicitTriggers }}
+    {{- if not $hasTopicSources }}
+    {{- fail "To use autoscaling, you must define one of .Values.kafka.inputTopics, .Values.autoscaling.internalTopics, .Values.autoscaling.topics, or .Values.kafka.labeledInputTopics, or use autoscaling.triggers to define fully custom triggers" }}
+    {{- end }}
+    {{- if not (and $uniqueId .Values.autoscaling.lagThreshold) }}
+    {{- fail "When autoscaling is enabled, you must set both .Values.kafka.applicationId (or .Values.kafka.groupId) and .Values.autoscaling.lagThreshold" }}
+    {{- end }}
   {{- end }}
   {{- $root := . -}}
 apiVersion: keda.sh/v1alpha1
@@ -37,9 +49,9 @@ spec:
   idleReplicaCount: {{ .Values.autoscaling.idleReplicas }}
   {{- end }}
   triggers:
-    {{- if not (or .Values.kafka.inputTopics .Values.autoscaling.internalTopics .Values.autoscaling.topics .Values.kafka.labeledInputTopics .Values.autoscaling.additionalTriggers) }}
-    {{- fail "To use autoscaling, you must define one of .Values.kafka.inputTopics, .Values.autoscaling.internalTopics, .Values.autoscaling.topics, .Values.kafka.labeledInputTopics or .Values.autoscaling.additionalTriggers" }}
-    {{- end}}
+    {{- if $explicitTriggers }}
+    {{- $explicitTriggers | toYaml | nindent 4 }}
+    {{- else }}
     # todo: concat .Values.kafka.inputTopics and .Values.autoscaling.topics to
     # minimize number of loops when we don't need to support helm 2 anymore
     {{- range .Values.kafka.inputTopics }}
@@ -80,11 +92,16 @@ spec:
         offsetResetPolicy: {{ $root.Values.autoscaling.offsetResetPolicy }}
     {{- end }}
     {{- end }}
-  {{- if .Values.autoscaling.additionalTriggers }}
-  {{- .Values.autoscaling.additionalTriggers | toYaml | nindent 4 }}
+  {{- if $additionalTriggers }}
+  {{- $additionalTriggers | toYaml | nindent 4 }}
   {{- end }}
+    {{- end }}
   advanced:
     horizontalPodAutoscalerConfig:
       name: {{ include "kafka-app.fullname" . }}
+    {{- with $scalingModifiers }}
+    scalingModifiers:
+      {{- . | toYaml | nindent 6 }}
+    {{- end }}
 {{ end }}
 {{- end -}}

--- a/charts/kafka-app/templates/_scaled-object.yaml
+++ b/charts/kafka-app/templates/_scaled-object.yaml
@@ -8,9 +8,12 @@
   {{- if and $explicitTriggers $additionalTriggers }}
   {{- fail "autoscaling.triggers and autoscaling.additionalTriggers cannot be used together" }}
   {{- end }}
+  {{- if and $scalingModifiers (not $explicitTriggers) }}
+  {{- fail "autoscaling.scalingModifiers requires autoscaling.triggers" }}
+  {{- end }}
   {{- if not $explicitTriggers }}
-    {{- if not $hasTopicSources }}
-    {{- fail "To use autoscaling, you must define one of .Values.kafka.inputTopics, .Values.autoscaling.internalTopics, .Values.autoscaling.topics, or .Values.kafka.labeledInputTopics, or use autoscaling.triggers to define fully custom triggers" }}
+    {{- if not (or $hasTopicSources $additionalTriggers) }}
+    {{- fail "To use autoscaling, you must define one of .Values.kafka.inputTopics, .Values.autoscaling.internalTopics, .Values.autoscaling.topics, .Values.kafka.labeledInputTopics, or .Values.autoscaling.additionalTriggers, or use autoscaling.triggers to define fully custom triggers" }}
     {{- end }}
     {{- if not (and $uniqueId .Values.autoscaling.lagThreshold) }}
     {{- fail "When autoscaling is enabled, you must set both .Values.kafka.applicationId (or .Values.kafka.groupId) and .Values.autoscaling.lagThreshold" }}

--- a/charts/streams-app/README.md
+++ b/charts/streams-app/README.md
@@ -113,7 +113,7 @@ podAnnotations:
 ### Auto-Scaling
 
 | Parameter                        | Description                                                                                                        | Default    |
-| -------------------------------- | ------------------------------------------------------------------------------------------------------------------ | ---------- |
+| -------------------------------- |--------------------------------------------------------------------------------------------------------------------| ---------- |
 | `autoscaling.enabled`            | Whether to enable auto-scaling using [KEDA](https://keda.sh/docs/latest/scalers/apache-kafka/).                    | `false`    |
 | `autoscaling.lagThreshold`       | Average target value to trigger scaling actions.                                                                   |            |
 | `autoscaling.pollingInterval`    | https://keda.sh/docs/2.10/concepts/scaling-deployments/#pollinginterval                                            | `30`       |
@@ -126,7 +126,7 @@ podAnnotations:
 | `autoscaling.topics`             | List of topics used by the streams app.                                                                            | `[]`       |
 | `autoscaling.additionalTriggers` | List of additional KEDA triggers, see https://keda.sh/docs/latest/scalers/                                         | `[]`       |
 | `autoscaling.triggers`           | Complete KEDA trigger list. A non-empty list replaces all generated Kafka lag triggers.                            | `[]`       |
-| `autoscaling.scalingModifiers`   | KEDA composite scaling configuration. Requires explicit triggers and KEDA 2.12 or newer.                           |            |
+| `autoscaling.scalingModifiers`   | KEDA composite scaling configuration. Requires explicit triggers.                                                  |            |
 
 ### JVM
 

--- a/charts/streams-app/README.md
+++ b/charts/streams-app/README.md
@@ -125,6 +125,8 @@ podAnnotations:
 | `autoscaling.internalTopics`     | List of auto-generated Kafka Streams topics used by the streams app. Consumer group prefix is added automatically. | `[]`       |
 | `autoscaling.topics`             | List of topics used by the streams app.                                                                            | `[]`       |
 | `autoscaling.additionalTriggers` | List of additional KEDA triggers, see https://keda.sh/docs/latest/scalers/                                         | `[]`       |
+| `autoscaling.triggers`           | Complete KEDA trigger list. A non-empty list replaces all generated Kafka lag triggers.                            | `[]`       |
+| `autoscaling.scalingModifiers`   | KEDA composite scaling configuration. Requires explicit triggers and KEDA 2.12 or newer.                           |            |
 
 ### JVM
 

--- a/charts/streams-app/values.yaml
+++ b/charts/streams-app/values.yaml
@@ -124,8 +124,7 @@ autoscaling:
   ## fully replaces automatically generated Kafka lag triggers when non-empty;
   ## mutually exclusive with additionalTriggers
   triggers: []
-  ## appended to automatically generated Kafka lag triggers in managed Kafka mode;
-  ## cannot be used without a Kafka topic source
+  ## appended to automatically generated Kafka lag triggers, or used as the sole trigger source
   additionalTriggers: []
 #    - type: metrics-api
 #      metadata:

--- a/charts/streams-app/values.yaml
+++ b/charts/streams-app/values.yaml
@@ -121,12 +121,23 @@ autoscaling:
   topics: []
   #   - bar
   #   - baz
+  ## fully replaces automatically generated Kafka lag triggers when non-empty;
+  ## mutually exclusive with additionalTriggers
+  triggers: []
+  ## appended to automatically generated Kafka lag triggers in managed Kafka mode;
+  ## cannot be used without a Kafka topic source
   additionalTriggers: []
 #    - type: metrics-api
 #      metadata:
 #        targetValue: "2"
 #        url: "http://custom-metrics-api"
 #        valueLocation: "some.json.path"
+  ## requires KEDA 2.12+ and explicit triggers
+  # scalingModifiers:
+  #   formula: "trigger_a + trigger_b"
+  #   target: "2"
+  #   activationTarget: "0"
+  #   metricType: AverageValue
 
 # serviceAccountName: foo
 

--- a/charts/streams-app/values.yaml
+++ b/charts/streams-app/values.yaml
@@ -132,7 +132,7 @@ autoscaling:
 #        targetValue: "2"
 #        url: "http://custom-metrics-api"
 #        valueLocation: "some.json.path"
-  ## requires KEDA 2.12+ and explicit triggers
+  ## requires explicit triggers
   # scalingModifiers:
   #   formula: "trigger_a + trigger_b"
   #   target: "2"


### PR DESCRIPTION
Allow apps to replace generated Kafka lag triggers with explicit KEDA triggers and configure scaling through scalingModifiers. Existing additionalTriggers behavior remains compatible.