### PR TITLE
Enable global processing exception handler by default

### DIFF
--- a/streams-bootstrap-core/src/main/java/com/bakdata/kafka/streams/ConfiguredStreamsApp.java
+++ b/streams-bootstrap-core/src/main/java/com/bakdata/kafka/streams/ConfiguredStreamsApp.java
@@ -82,6 +82,8 @@ public class ConfiguredStreamsApp<T extends StreamsApp> implements ConfiguredApp
      * producer.compression.type=gzip
      * </pre>
      *     </li>
+     *     <li>Explicit internal resource naming is enforced</li>
+     *     <li>Global processing exception handler is enabled</li>
      *     <li>
      *         Configs provided by {@link StreamsApp#createKafkaProperties()}
      *     </li>

--- a/streams-bootstrap-core/src/main/java/com/bakdata/kafka/streams/ConfiguredStreamsApp.java
+++ b/streams-bootstrap-core/src/main/java/com/bakdata/kafka/streams/ConfiguredStreamsApp.java
@@ -64,6 +64,7 @@ public class ConfiguredStreamsApp<T extends StreamsApp> implements ConfiguredApp
                 CompressionType.GZIP.toString());
 
         kafkaConfig.put(StreamsConfig.ENSURE_EXPLICIT_INTERNAL_RESOURCE_NAMING_CONFIG, true);
+        kafkaConfig.put(StreamsConfig.PROCESSING_EXCEPTION_HANDLER_GLOBAL_ENABLED_CONFIG, true);
 
         return kafkaConfig;
     }

--- a/streams-bootstrap-core/src/test/java/com/bakdata/kafka/streams/kstream/ConfiguredStreamsAppTest.java
+++ b/streams-bootstrap-core/src/test/java/com/bakdata/kafka/streams/kstream/ConfiguredStreamsAppTest.java
@@ -243,6 +243,14 @@ class ConfiguredStreamsAppTest {
                 .hasMessageStartingWith("Invalid topology:");
     }
 
+    @Test
+    void shouldEnableGlobalProcessingExceptionHandler() {
+        final ConfiguredStreamsApp<StreamsApp> configuredApp =
+                new ConfiguredStreamsApp<>(new TestApplication(), newAppConfiguration());
+        assertThat(configuredApp.getKafkaProperties(RuntimeConfiguration.create("fake")))
+                .containsEntry(StreamsConfig.PROCESSING_EXCEPTION_HANDLER_GLOBAL_ENABLED_CONFIG, true);
+    }
+
     @RequiredArgsConstructor
     private static class TestApplication implements StreamsApp {
 


### PR DESCRIPTION
Will be enabled with Kafka 5.0 by default. Prevents log `Processing exception handler is not enabled for the GlobalThread.`